### PR TITLE
Update FlashHelper to fix error in Cakephp 3.1.3

### DIFF
--- a/src/View/Helper/BootstrapFlashHelper.php
+++ b/src/View/Helper/BootstrapFlashHelper.php
@@ -70,7 +70,7 @@ class BootstrapFlashHelper extends FlashHelper {
      * @throws \UnexpectedValueException If value for flash settings key is not an array.
      */
     public function render($key = 'flash', array $options = []) {
-        if (!$this->request->session()->check("Flash.$key")) {
+         if (!$this->request->session()->check("Flash.$key")) {
             return;
         }
 
@@ -81,15 +81,14 @@ class BootstrapFlashHelper extends FlashHelper {
                 $key
             ));
         }
-        $flash = $options + $flash;
-        $this->request->session()->delete("Flash.$key");
-
-        $element = $flash['element'] ;
-        if (in_array(basename($element), $this->_bootstrapTemplates)) {
-            $flash['element'] = 'Bootstrap.'.$element ;
+        foreach ($flash as &$message) {
+        	if (in_array(basename($message['element']), $this->_bootstrapTemplates)) {
+        		$message['element'] = 'Bootstrap.'.$message['element'];
+        	}
         }
+        $this->request->session()->write("Flash.$key", $flash);
 
-        return $this->_View->element($flash['element'], $flash);
+        return parent::render($key, $options);
     }
 
 }


### PR DESCRIPTION
FlashHelper::render() in Cakephp is setup to render multiple flash messages.  PR modifies the Bootstrap helper to update the element value for each flash message and then passes off rendering to the core render function.
